### PR TITLE
Use GODEP_BIN variable in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ GODEP_BIN := $(GOPATH)/bin/godep
 default: build
 
 bin/docker-machine-driver-opennebula:
-	godep go build -o ./bin/docker-machine-driver-opennebula ./bin 
+	$(GODEP_BIN) go build -o ./bin/docker-machine-driver-opennebula ./bin 
 
 build: clean bin/docker-machine-driver-opennebula
 


### PR DESCRIPTION
The Makefile already defines the variable GODEP_BIN, but it was not yet used in the rules.
